### PR TITLE
Implement rewake timer, shutdown grace timer, startup reason

### DIFF
--- a/app/app_config.h
+++ b/app/app_config.h
@@ -1,6 +1,6 @@
 #pragma once
 
 #define VERSION_MAJOR		2
-#define VERSION_MINOR		1
+#define VERSION_MINOR		2
 
 #define KEY_FIFO_SIZE		31       // number of keys in the public FIFO

--- a/app/keyboard.c
+++ b/app/keyboard.c
@@ -124,8 +124,11 @@ static void transition_hold_key_state(struct hold_key* hold_key, bool const pres
 
 						keyboard_inject_power_key();
 
-						// Schedule power off in one minute to give Pi time to shut down
-						pi_schedule_power_off(60 * 1000);
+						// Schedule power off
+						uint32_t shutdown_grace_ms = MAX(
+							reg_get_value(REG_ID_SHUTDOWN_GRACE) * 1000,
+							MINIMUM_SHUTDOWN_GRACE_MS);
+						pi_schedule_power_off(shutdown_grace_ms);
 
 						hold_key->state = KEY_STATE_LONG_HOLD;
 					}

--- a/app/keyboard.c
+++ b/app/keyboard.c
@@ -73,13 +73,6 @@ static int64_t release_power_key_alarm_callback(alarm_id_t _, void* __)
 	return 0;
 }
 
-static int64_t pi_power_on_alarm_callback(alarm_id_t _, void* __)
-{
-	pi_power_on();
-
-	return 0;
-}
-
 static void transition_hold_key_state(struct hold_key* hold_key, bool const pressed)
 {
 	uint key_held_for;
@@ -118,7 +111,7 @@ static void transition_hold_key_state(struct hold_key* hold_key, bool const pres
 
 				// Driver unloaded, power back on
 				if (reg_get_value(REG_ID_DRIVER_STATE) == 0) {
-					add_alarm_in_ms(10, pi_power_on_alarm_callback, NULL, true);
+					pi_power_on(POWER_ON_BUTTON);
 					hold_key->state = KEY_STATE_LONG_HOLD;
 
 				// Driver loaded, send power off
@@ -129,9 +122,10 @@ static void transition_hold_key_state(struct hold_key* hold_key, bool const pres
 						- hold_key->hold_start_time;
 					if (key_held_for > LONG_HOLD_MS) {
 
-						// Simulate press event and schedule release
-						keyboard_inject_event(KEY_POWER, KEY_STATE_PRESSED);
-						add_alarm_in_ms(10, release_power_key_alarm_callback, NULL, true);
+						keyboard_inject_power_key();
+
+						// Schedule power off in one minute to give Pi time to shut down
+						pi_schedule_power_off(60 * 1000);
 
 						hold_key->state = KEY_STATE_LONG_HOLD;
 					}
@@ -273,6 +267,13 @@ void keyboard_inject_event(uint8_t key, enum key_state state)
 		cb->func(key, state);
 		cb = cb->next;
 	}
+}
+
+// Simulate press event and schedule release
+void keyboard_inject_power_key()
+{
+	keyboard_inject_event(KEY_POWER, KEY_STATE_PRESSED);
+	add_alarm_in_ms(10, release_power_key_alarm_callback, NULL, true);
 }
 
 void keyboard_add_key_callback(struct key_callback *callback)

--- a/app/keyboard.h
+++ b/app/keyboard.h
@@ -23,6 +23,7 @@ struct key_callback
 };
 
 void keyboard_inject_event(uint8_t key, enum key_state state);
+void keyboard_inject_power_key();
 
 void keyboard_add_key_callback(struct key_callback *callback);
 

--- a/app/main.c
+++ b/app/main.c
@@ -54,7 +54,8 @@ int main(void)
 
 	led_init();
 	pi_power_init();
-	pi_power_on();
+
+	pi_power_on(POWER_ON_FW_INIT);
 
 #ifndef NDEBUG
 	printf("Starting main loop\r\n");

--- a/app/pi.h
+++ b/app/pi.h
@@ -9,6 +9,7 @@ enum power_on_reason
 	POWER_ON_REWAKE = 0x3 // 0x2 = Pi was reawakened from a scheduled timer
 };
 
+#define MINIMUM_SHUTDOWN_GRACE_MS 5000
 
 void pi_power_init(void);
 void pi_power_on(enum power_on_reason reason);

--- a/app/pi.h
+++ b/app/pi.h
@@ -2,8 +2,20 @@
 
 #include <stdint.h>
 
+enum power_on_reason
+{
+	POWER_ON_FW_INIT = 0x1, // RP2040 initialized
+	POWER_ON_BUTTON = 0x2, // Power button held after Pi was shut down
+	POWER_ON_REWAKE = 0x3 // 0x2 = Pi was reawakened from a scheduled timer
+};
+
+
 void pi_power_init(void);
-void pi_power_on(void);
+void pi_power_on(enum power_on_reason reason);
+void pi_power_off(void);
+
+void pi_schedule_power_on(uint32_t ms);
+void pi_schedule_power_off(uint32_t ms);
 
 void led_sync(void);
 void led_init(void);

--- a/app/reg.c
+++ b/app/reg.c
@@ -59,8 +59,8 @@ void reg_process_packet(uint8_t in_reg, uint8_t in_data, uint8_t *out_buffer, ui
 	case REG_ID_ADR:
 	case REG_ID_IND:
 	case REG_ID_CF2:
-	case REG_ID_REWAKE_TIME:
 	case REG_ID_DRIVER_STATE:
+	case REG_ID_SHUTDOWN_GRACE:
 	{
 		if (is_write) {
 			reg_set_value(reg, in_data);
@@ -147,9 +147,34 @@ void reg_process_packet(uint8_t in_reg, uint8_t in_data, uint8_t *out_buffer, ui
 		break;
 	}
 
-	// Reawake timer
-	case REG_ID_REWAKE:
+	// Rewake on timer
+	case REG_ID_REWAKE_MINS:
 	{
+		// Only run this if driver was loaded
+		// Otherwise, OS won't get the power key event
+		if (reg_get_value(REG_ID_DRIVER_STATE) == 0) {
+			break;
+		}
+
+		// Get rewake and grace times in milliseconds
+		uint32_t rewake_ms = in_data * 60 * 1000;
+		uint32_t shutdown_grace_ms = reg_get_value(REG_ID_SHUTDOWN_GRACE) * 1000;
+
+		// Check input time against shutdown grace time
+		// Plus some slop to allow for power cycling
+		if (rewake_ms < (shutdown_grace_ms + 5000)) {
+			break;
+		}
+
+		// Send shutdown signal to OS
+		keyboard_inject_power_key();
+
+		// Power off with grace time to give Pi time to shut down
+		pi_schedule_power_off(shutdown_grace_ms);
+
+		// Schedule power on
+		pi_schedule_power_on(rewake_ms);
+
 		break;
 	}
 
@@ -197,7 +222,7 @@ void reg_process_packet(uint8_t in_reg, uint8_t in_data, uint8_t *out_buffer, ui
 		out_buffer[0] = (uint8_t)(adc_value & 0x00FF);
 		out_buffer[1] = (uint8_t)((adc_value & 0xFF00) >> 8);
 		*out_len = sizeof(uint8_t) * 2;
-		break;		
+		break;
 
 	case REG_ID_KEY:
 		out_buffer[0] = fifo_count();
@@ -216,6 +241,11 @@ void reg_process_packet(uint8_t in_reg, uint8_t in_data, uint8_t *out_buffer, ui
 
 	case REG_ID_RST:
 		NVIC_SystemReset();
+		break;
+
+	case REG_ID_STARTUP_REASON:
+		out_buffer[0] = reg_get_value(reg);
+		*out_len = sizeof(uint8_t);
 		break;
 	}
 }
@@ -270,6 +300,8 @@ void reg_init(void)
 	reg_set_value(REG_ID_IND, 1);	// ms
 	reg_set_value(REG_ID_CF2, CF2_TOUCH_INT | CF2_USB_KEYB_ON | CF2_USB_MOUSE_ON);
 	reg_set_value(REG_ID_DRIVER_STATE, 0); // Driver not yet loaded
+
+	reg_set_value(REG_ID_SHUTDOWN_GRACE, 45);
 
 	touchpad_add_touch_callback(&touch_callback);
 }

--- a/app/reg.c
+++ b/app/reg.c
@@ -158,7 +158,9 @@ void reg_process_packet(uint8_t in_reg, uint8_t in_data, uint8_t *out_buffer, ui
 
 		// Get rewake and grace times in milliseconds
 		uint32_t rewake_ms = in_data * 60 * 1000;
-		uint32_t shutdown_grace_ms = reg_get_value(REG_ID_SHUTDOWN_GRACE) * 1000;
+		uint32_t shutdown_grace_ms = MAX(
+			reg_get_value(REG_ID_SHUTDOWN_GRACE) * 1000,
+			MINIMUM_SHUTDOWN_GRACE_MS);
 
 		// Check input time against shutdown grace time
 		// Plus some slop to allow for power cycling

--- a/app/reg.h
+++ b/app/reg.h
@@ -34,8 +34,8 @@ enum reg_id
 	REG_ID_LED_G  = 0x22,
 	REG_ID_LED_B  = 0x23,
 
-	REG_ID_REWAKE_TIME = 0x24, // Power on the Pi in this many minutes
-	REG_ID_REWAKE = 0x25, // Write to shut off Pi, power on after REWAKE_TIME
+	REG_ID_REWAKE_MINS = 0x24, // Write to turn off Pi, power on in this many mins
+	REG_ID_SHUTDOWN_GRACE = 0x25, // Seconds to wait between shutdown signal and power off
 
 	REG_ID_RTC_SEC = 0x26,
 	REG_ID_RTC_MIN = 0x27,
@@ -46,6 +46,8 @@ enum reg_id
 	REG_ID_RTC_COMMIT = 0x2C,
 
 	REG_ID_DRIVER_STATE = 0x2D, // Set when driver is loaded / unloaded cleanly
+
+	REG_ID_STARTUP_REASON = 0x2E, // Why the Pi was started (see `power_on_reason` in pi.h)
 
 	REG_ID_LAST,
 };


### PR DESCRIPTION
New I2C registers:

- `0x24`: Shutdown Pi and trigger rewake in that many minutes
- `0x25`: Grace period between sending shutdown signal and hard power off to Pi (default 45 seconds)
- `0x2E`: Reason for the current startup of the Pi (firmware init, power button, rewake timer)